### PR TITLE
Fix browser sniffing

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -11,12 +11,12 @@ function getBrowserInfo() {
   };
   let matches;
 
-  matches = navigator.userAgent.match(/(Chrome)\/(\d\d)/);
+  matches = navigator.userAgent.match(/(Chrome)\/(\d\d+)/);
   if (matches) {
     result.name = matches[1];
     result.version = parseInt(matches[2]);
   }
-  matches = navigator.userAgent.match(/(Firefox)\/(\d\d)/);
+  matches = navigator.userAgent.match(/(Firefox)\/(\d\d+)/);
   if (matches) {
     result.name = matches[1];
     result.version = parseInt(matches[2]);


### PR DESCRIPTION
Browsers now have three-digit version numbers.  As a result the current code reads Firefox 134 as Firefox 13, and claims the browser is too old.